### PR TITLE
修复go默认禁用的ssh算法导致无法连接握手失败的异常

### DIFF
--- a/core/server.go
+++ b/core/server.go
@@ -49,6 +49,9 @@ func (server *Server) Connect() {
 	config := &ssh.ClientConfig{
 		User: server.User,
 		Auth: auths,
+		Config: ssh.Config{
+			Ciphers: []string{"aes128-ctr", "aes192-ctr", "aes256-ctr", "aes128-gcm@openssh.com", "arcfour256", "arcfour128", "aes128-cbc", "3des-cbc", "aes192-cbc", "aes256-cbc"},
+		},
 		HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 			return nil
 		},


### PR DESCRIPTION
增加go的crypto的客户端加密方式的配置，官方默认未启用一些安全级别低的加密方式，但是由于某些服务器的操作系统版本低，仍然需要配置，否则会ssh握手失败，具体官方说明请参考https://github.com/golang/go/issues/20201，
修复 Fixes #6 